### PR TITLE
Add discovery of SLF4J 2.0+

### DIFF
--- a/kodein-log/src/jvmMain/kotlin/org/kodein/log/frontend/defaultJvm.kt
+++ b/kodein-log/src/jvmMain/kotlin/org/kodein/log/frontend/defaultJvm.kt
@@ -1,14 +1,26 @@
 package org.kodein.log.frontend
 
 import org.kodein.log.LogFrontend
+import java.util.ServiceLoader
 
-private fun isSlf4jAvailable(): Boolean =
-        try {
-            Class.forName("org.slf4j.impl.StaticLoggerBinder")
-            true
-        } catch (_: ClassNotFoundException) {
-            false
-        }
+private fun isSlf4jAvailable(): Boolean {
+    // SLF4J 1.0 - 1.7
+    try {
+        Class.forName("org.slf4j.impl.StaticLoggerBinder")
+        return true
+    } catch (_: ClassNotFoundException) {
+    }
+
+    // SLF4J 2.0+
+    try {
+        val slf4jSpi = Class.forName("org.slf4j.spi.SLF4JServiceProvider")
+        val loader = ServiceLoader.load(slf4jSpi)
+        return loader.any()
+    } catch (_: ClassNotFoundException) {
+    }
+
+    return false
+}
 
 private fun isAndroidAvailable(): Boolean =
         try {


### PR DESCRIPTION
StaticLoggerBinder is gone in slf4j 2.0.0, and now it uses SPI to load logger implementations at runtime.